### PR TITLE
Gives security access to wall Nanomed vendors

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -1173,7 +1173,7 @@
 
 	charge_free_department = DEPT_HEALTHCARE
 	block_persistence = TRUE
-	req_access = list(access_medical)
+	req_access = list(access_medical, access_security)
 
 /obj/machinery/vending/wallmed1/gcch
 	vendor_department = DEPT_HEALTHCARE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Police officers can't access the walled Nanomed vendors in the police hallway to provide first aid.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Police players can't access the wall nanomed vendors in the PD hallway. Plus, it would be logic for LEOs to provide fist aid given some situations before medical professionals can take over.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added more things
tweak: tweaked a few things
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->